### PR TITLE
Avoid loading admin_static in templates under Django>=1.10

### DIFF
--- a/rangefilter/templates/rangefilter/date_filter.html
+++ b/rangefilter/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
 <style>

--- a/rangefilter/templates/rangefilter/date_filter.html
+++ b/rangefilter/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n static_or_admin_static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
 <style>

--- a/rangefilter/templates/rangefilter/date_filter_1_8.html
+++ b/rangefilter/templates/rangefilter/date_filter_1_8.html
@@ -1,4 +1,4 @@
-{% load i18n static %}
+{% load i18n admin_static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
 <style>

--- a/rangefilter/templates/rangefilter/date_filter_1_8.html
+++ b/rangefilter/templates/rangefilter/date_filter_1_8.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <link rel="stylesheet" type="text/css" href="{% static 'admin/css/widgets.css' %}">
 <style>

--- a/rangefilter/templatetags/static_or_admin_static.py
+++ b/rangefilter/templatetags/static_or_admin_static.py
@@ -1,0 +1,14 @@
+import django
+from django.template import Library
+
+register = Library()
+
+
+@register.simple_tag()
+def static(path):
+    if django.VERSION[:2] >= (1, 10):
+        from django.templatetags.static import static as _static
+    else:
+        from django.contrib.admin.templatetags.admin_static import static as _static
+
+    return _static(path)

--- a/rangefilter/tests.py
+++ b/rangefilter/tests.py
@@ -12,6 +12,7 @@ except ImportError:
 from unittest import skipIf
 
 from django.utils import timezone
+from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.db import models
@@ -274,3 +275,18 @@ class DateTimeRangeFilterTestCase(TestCase):
         choice = select_by(filterspec.choices(changelist))
         self.assertEqual(choice['query_string'], '?')
         self.assertEqual(choice['system_name'], 'created-at')
+
+
+class StaticOrAdminStaticTestCase(TestCase):
+
+    def test_renders_static_path_to_asset(self):
+        context = Context()
+        test_template = Template('{% load static_or_admin_static %}'
+                                 '<link rel="stylesheet" type="text/css" '
+                                 'href="{% static \'admin/css/widgets.css\' %}">')
+
+        rendered_template = test_template.render(context)
+
+        self.assertEqual(rendered_template,
+                         '<link rel="stylesheet" type="text/css" '
+                         'href="admin/css/widgets.css">')

--- a/runtests.py
+++ b/runtests.py
@@ -23,6 +23,21 @@ settings.configure(
     TEST_RUNNER='django.test.runner.DiscoverRunner',
     USE_TZ=True,
     TIME_ZONE='UTC',
+    TEMPLATES=[
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
 )
 
 django.setup()

--- a/runtests.py
+++ b/runtests.py
@@ -23,21 +23,7 @@ settings.configure(
     TEST_RUNNER='django.test.runner.DiscoverRunner',
     USE_TZ=True,
     TIME_ZONE='UTC',
-    TEMPLATES=[
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [],
-            'APP_DIRS': True,
-            'OPTIONS': {
-                'context_processors': [
-                    'django.template.context_processors.debug',
-                    'django.template.context_processors.request',
-                    'django.contrib.auth.context_processors.auth',
-                    'django.contrib.messages.context_processors.messages',
-                ],
-            },
-        },
-    ]
+    STATIC_URL='/static/',
 )
 
 django.setup()


### PR DESCRIPTION
- `admin_static` [loses functionality in Django 1.10](https://github.com/django/django/blob/stable/1.10.x/django/contrib/admin/templatetags/admin_static.py)
- Fixes #26 