### PR TITLE
Avoided leading ?& GET parameters.

### DIFF
--- a/rangefilter/static/rangefilter/iife.js
+++ b/rangefilter/static/rangefilter/iife.js
@@ -12,7 +12,8 @@
         function(event){
           event.preventDefault();
           var form_data = django.jQuery('#'+form_name).serialize();
-          window.location = window.location.pathname + query_string + '&' + form_data;
+          amp = query_string == "?" ? "" : "&";  // avoid leading ?& combination
+          window.location = window.location.pathname + query_string + amp + form_data;
       });
 
       // Bind reset buttons

--- a/rangefilter/templates/rangefilter/date_filter.html
+++ b/rangefilter/templates/rangefilter/date_filter.html
@@ -72,7 +72,8 @@ https://github.com/django/django/blob/stable/1.10.x/django/contrib/admin/templat
         event.preventDefault();
         var query_string = django.jQuery('input#'+qs_name).val();
         var form_data = django.jQuery('#'+form_name).serialize();
-        window.location = window.location.pathname + query_string + '&' + form_data;
+        amp = query_string == "?" ? "" : "&";  // avoid leading ?& combination
+        window.location = window.location.pathname + query_string + amp + form_data;
     }
     function datefilter_reset(qs_name){
         var query_string = django.jQuery('input#'+qs_name).val();

--- a/rangefilter/templates/rangefilter/date_filter_1_8.html
+++ b/rangefilter/templates/rangefilter/date_filter_1_8.html
@@ -60,8 +60,8 @@ https://github.com/django/django/blob/stable/1.8.x/django/contrib/admin/template
     function datefilter_apply(event, qs_name, form_name){
         event.preventDefault();
         var query_string = django.jQuery('input#'+qs_name).val();
-        var form_data = django.jQuery('#'+form_name).serialize();
-        window.location = window.location.pathname + query_string + '&' + form_data;
+        amp = query_string == "?" ? "" : "&";  // avoid leading ?& combination
+        window.location = window.location.pathname + query_string + amp + form_data;
     }
     function datefilter_reset(qs_name){
         var query_string = django.jQuery('input#'+qs_name).val();


### PR DESCRIPTION
I encountered an issue with another package that did javascript parsing of URL parameters. It was creating a key-value pair with an empty string key and an undefined value. Tracing it back, it seems to be because in some instances, django-admin-rangefilter prepends the first argument with '&', leading to '?&key=val'. I think this change will eliminate that possibility, but please let me know if you think changes are required!