### PR TITLE
Fix django app config default warning

### DIFF
--- a/rangefilter/__init__.py
+++ b/rangefilter/__init__.py
@@ -7,7 +7,10 @@ import django
 __author__ = 'Dmitriy Sokolov'
 __version__ = '0.8.4'
 
-if django.VERSION < (3, 2):
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
     default_app_config = 'rangefilter.apps.RangeFilterConfig'
 
 


### PR DESCRIPTION
What does this PR do ?

It solves the fix warnings default_app_config.
Full error details :

`RemovedInDjango41Warning: 'rangefilter' defines default_app_config = 'rangefilter.apps.RangeFilterConfig'. Django now detects this configuration automatically. You can remove default_app_config.
`