### PR TITLE
Use current timezone instead of default

### DIFF
--- a/rangefilter/filters.py
+++ b/rangefilter/filters.py
@@ -154,7 +154,7 @@ class DateRangeFilter(BaseRangeFilter):
         return form_class(self.used_parameters or None)
 
     def get_timezone(self, _request):
-        return timezone.get_default_timezone()
+        return timezone.get_current_timezone()
 
     @staticmethod
     def make_dt_aware(value, tzname):


### PR DESCRIPTION
If the timezone is set using this approach from the Django [docs](https://docs.djangoproject.com/en/5.0/topics/i18n/timezones/#selecting-the-current-time-zone) then it should be using the current timezone not the default one.