### PR TITLE
DateTimeRangeFilter upper time bound includes microseconds

### DIFF
--- a/rangefilter/filters.py
+++ b/rangefilter/filters.py
@@ -277,7 +277,7 @@ class DateTimeRangeFilter(DateRangeFilter):
         if date_value_lte:
             query_params["{0}__lte".format(self.field_path)] = self.make_dt_aware(
                 date_value_lte, self.get_timezone(request)
-            )
+            ).replace(microsecond=999999)
 
         return query_params
 


### PR DESCRIPTION
In Django admin we can input time range 00:00:00 to 23:59:59 (or another time range) into text fields. The db-query does not consider the last second, since we do not take into account microseconds: WHERE "created_at" >= '''2024-02-13 00:00:00''' AND "created_at" <= '''2024-02-13 23:59:59.999999'''