### PR TITLE
fix initial value in NumericRangeFilter form field

### DIFF
--- a/rangefilter/filters.py
+++ b/rangefilter/filters.py
@@ -339,7 +339,7 @@ class NumericRangeFilter(BaseRangeFilter):
                         widget=forms.NumberInput(attrs={"placeholder": _("From")}),
                         required=False,
                         localize=True,
-                        initial=self.default_lte,
+                        initial=self.default_gte,
                     ),
                 ),
                 (


### PR DESCRIPTION
Fixes #123

Fix initial value in NumericRangeFilter form field to show default_start value (default_gte) instead of default_end value (default_lte)