### PR TITLE
fix: Prevent datetimeshortcuts from rendering multiple times

### DIFF
--- a/rangefilter/templates/rangefilter/date_filter.html
+++ b/rangefilter/templates/rangefilter/date_filter.html
@@ -131,7 +131,7 @@ https://github.com/django/django/blob/stable/1.10.x/django/contrib/admin/templat
         });
     }
 
-    django.jQuery('document').ready(function () {
+    django.jQuery(window).on('load', function () {
         if (!('DateTimeShortcuts' in window)) {
             var promiseList = [];
 

--- a/rangefilter/templates/rangefilter/date_filter_4_0.html
+++ b/rangefilter/templates/rangefilter/date_filter_4_0.html
@@ -127,7 +127,7 @@ https://github.com/django/django/blob/stable/1.10.x/django/contrib/admin/templat
         });
     }
 
-    django.jQuery('document').ready(function () {
+    django.jQuery(window).on('load', function () {
         if (!('DateTimeShortcuts' in window)) {
             var promiseList = [];
 


### PR DESCRIPTION
This was happening because scripts injected inside `$(document).ready(...)` would delay onload event and django's DateTimeShortcuts script attaches an event handler to `load` event to initialize the widgets. What would happen is our own initialization would run first and the one coming from django second resulting in duplicate widget. This change ensures our initialization happens last.

See #128