### PR TITLE
Update test coverage to include Django 5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,18 +74,25 @@ jobs:
             django-version: "4.0.*"
           - python-version: "3.10"
             django-version: "4.1.*"
+          - python-version: "3.10"
+            django-version: "5.0.*"
+          - python-version: "3.10"
+            django-version: "5.1.*"
 
           - python-version: "3.11"
             django-version: "4.2.*"
-
           - python-version: "3.11"
             django-version: "5.0.*"
             coverage: true
+          - python-version: "3.11"
+            django-version: "5.1.*"
 
           - python-version: "3.12"
-            django-version: "4.2.*"
+            django-version: "4.2.*,>=4.2.8"
           - python-version: "3.12"
             django-version: "5.0.*"
+          - python-version: "3.12"
+            django-version: "5.1.*"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Also adding missing Django 5.0 on Python 3.10 support.

And making sure that for Django 4.2 that the Python 3.2 tests happen with [at least 4.2.8](https://docs.djangoproject.com/en/5.1/releases/4.2/#python-compatibility).